### PR TITLE
Upload arm64 mac build instead of x86

### DIFF
--- a/zen/publish/action.yml
+++ b/zen/publish/action.yml
@@ -48,8 +48,7 @@ runs:
           echo "${ARTIFACTORY_REPO}/${REPOSITORY_NAME}/${ZEN_VERSION}-${CURRENT_BRANCH^^}-${JFROG_CLI_BUILD_NUMBER}/windows/zowe-enterprise-necessity-${ZEN_VERSION}\ Setup.exe"
         elif [ "${{ inputs.os }}" = "macos" ];
         then
-          ls -ltr
-          jfrog rt u zowe-enterprise-necessity-${ZEN_VERSION}-x64.dmg ${ARTIFACTORY_REPO}/${REPOSITORY_NAME}/${ZEN_VERSION}-${CURRENT_BRANCH:u}-${JFROG_CLI_BUILD_NUMBER}/mac/zowe-enterprise-necessity-${ZEN_VERSION}-arm64.dmg
+          jfrog rt u zowe-enterprise-necessity-${ZEN_VERSION}-arm64.dmg ${ARTIFACTORY_REPO}/${REPOSITORY_NAME}/${ZEN_VERSION}-${CURRENT_BRANCH:u}-${JFROG_CLI_BUILD_NUMBER}/mac/zowe-enterprise-necessity-${ZEN_VERSION}-arm64.dmg
           echo "${ARTIFACTORY_REPO}/${REPOSITORY_NAME}/${ZEN_VERSION}-${CURRENT_BRANCH:u}-${JFROG_CLI_BUILD_NUMBER}/mac/zowe-enterprise-necessity-${ZEN_VERSION}-arm64.dmg"
         elif [ "${{ inputs.os }}" = "ubuntu" ];
         then

--- a/zen/publish/action.yml
+++ b/zen/publish/action.yml
@@ -48,8 +48,9 @@ runs:
           echo "${ARTIFACTORY_REPO}/${REPOSITORY_NAME}/${ZEN_VERSION}-${CURRENT_BRANCH^^}-${JFROG_CLI_BUILD_NUMBER}/windows/zowe-enterprise-necessity-${ZEN_VERSION}\ Setup.exe"
         elif [ "${{ inputs.os }}" = "macos" ];
         then
-          jfrog rt u zowe-enterprise-necessity-${ZEN_VERSION}-x64.dmg ${ARTIFACTORY_REPO}/${REPOSITORY_NAME}/${ZEN_VERSION}-${CURRENT_BRANCH:u}-${JFROG_CLI_BUILD_NUMBER}/mac/zowe-enterprise-necessity-${ZEN_VERSION}-x64.dmg
-          echo "${ARTIFACTORY_REPO}/${REPOSITORY_NAME}/${ZEN_VERSION}-${CURRENT_BRANCH:u}-${JFROG_CLI_BUILD_NUMBER}/mac/zowe-enterprise-necessity-${ZEN_VERSION}-x64.dmg"
+          ls -ltr
+          jfrog rt u zowe-enterprise-necessity-${ZEN_VERSION}-x64.dmg ${ARTIFACTORY_REPO}/${REPOSITORY_NAME}/${ZEN_VERSION}-${CURRENT_BRANCH:u}-${JFROG_CLI_BUILD_NUMBER}/mac/zowe-enterprise-necessity-${ZEN_VERSION}-arm64.dmg
+          echo "${ARTIFACTORY_REPO}/${REPOSITORY_NAME}/${ZEN_VERSION}-${CURRENT_BRANCH:u}-${JFROG_CLI_BUILD_NUMBER}/mac/zowe-enterprise-necessity-${ZEN_VERSION}-arm64.dmg"
         elif [ "${{ inputs.os }}" = "ubuntu" ];
         then
           cd deb/x64


### PR DESCRIPTION
The electron builder + github workflow combo is now using arm64 arch, so the x64.dmg asset is not found.
This is generally a good thing as few if any x64 macos users are expected for our use cases by now.
Ideally it would be better to build both, or a unified build, but not sure about how yet. This can work until such a solution is found.