### PR TITLE
add new step for updating build info in manifest

### DIFF
--- a/plugins/prepare-workflow/action.yml
+++ b/plugins/prepare-workflow/action.yml
@@ -67,7 +67,30 @@ runs:
         echo GITHUB_REPOSITORY=${{ github.repository }} >> $GITHUB_ENV
         echo DEPLOY_BRANCH=$CURRENT_BRANCH | sed -e 's+\/+\-+' >> $GITHUB_ENV
       shell: bash
-    
+
+    - name: 'update build info in manifest.yaml'
+      run: |
+        cd "$GITHUB_WORKSPACE"
+        MANIFEST_PATH=manifest.yaml
+        CURRENT_BRANCH=$(git branch --show-current)
+        COMMIT_HASH=$(git rev-parse HEAD)
+        CURRENT_TIMESTAMP=$(date +%s%3N)
+
+        if [ -f "$MANIFEST_PATH" ]; then
+          echo "updating $MANIFEST_PATH"
+          sed -e "s|{{build\.branch}}|${CURRENT_BRANCH}|g" \
+              -e "s|{{build\.number}}|${GITHUB_RUN_NUMBER}|g" \
+              -e "s|{{build\.commitHash}}|${COMMIT_HASH}|g" \
+              -e "s|{{build\.timestamp}}|${CURRENT_TIMESTAMP}|g" \
+              "$MANIFEST_PATH" > "${MANIFEST_PATH}.tmp"
+              mv "${MANIFEST_PATH}.tmp" "$MANIFEST_PATH"
+              echo "${MANIFEST_PATH}:"
+              cat "$MANIFEST_PATH"
+        else
+          echo "$MANIFEST_PATH not found. No build info was recorded. Please add a template manifest in this repo. explorer-jes/$MANIFEST_PATH is a good example."
+        fi
+      shell: bash
+
     - name: 'set plugin version'
       run: |
         if [ ! -n ${{ inputs.plugin-version }} ]
@@ -106,4 +129,3 @@ runs:
           echo RELEASE=false >> $GITHUB_ENV
         fi
       shell: bash
-    


### PR DESCRIPTION
Fix #43 

Zlux plugins built by workflows in `zowe-actions/zlux-builds/plugins` do not have correct build-info in their manifest.yaml.

The staging [tn3270-ng2-3.3.0-20250630.085018.pax](https://zowe.jfrog.io/artifactory/libs-snapshot-local/org/zowe/zlux/tn3270-ng2/3.3.0-V3.X-STAGING/tn3270-ng2-3.3.0-20250630.085018.pax) is an example of this problem.

This PR adds an additional step in `zowe-actions/zlux-builds/plugins/prepare-worflow` that updates the manifest.yaml with the correct build-info.

As a comparison, [tn3270-ng2-3.3.0-20250630.110159.pax](https://zowe.jfrog.io/artifactory/libs-snapshot-local/org/zowe/zlux/tn3270-ng2/3.3.0-USER-ZHOU/FIX-MANIFEST-BUILD-INFO/tn3270-ng2-3.3.0-20250630.110159.pax) was built by the workflow from this PR's branch. The manifest.yaml has correct build-info.