### PR TITLE
fix commitHash in core/build (ported change from PR#44)

### DIFF
--- a/core/build/action.yml
+++ b/core/build/action.yml
@@ -107,7 +107,7 @@ runs:
           cat version.properties
           cd ../zlux-app-server
           if [ -e "manifest.yaml" ]; then
-            export commit_hash=$(git rev-parse --short "$GITHUB_SHA")
+            export commit_hash=$(git rev-parse --short HEAD)
             export current_timestamp=$(date +%s%3N)
             export zlux_version="${majorVersion}.${minorVersion}.${microVersion}"
             echo $commit_hash
@@ -129,7 +129,7 @@ runs:
         for apps in $SYSTEM_APPS
         do
           cd $apps
-          export commit_hash=$(git rev-parse --short "$GITHUB_SHA")
+          export commit_hash=$(git rev-parse --short HEAD)
           export current_timestamp=$(date +%s%3N)
           sed -i -e "s|{{build\\.branch}}|${CURRENT_BRANCH}|g" \
                    -e "s|{{build\\.number}}|${JFROG_CLI_BUILD_NUMBER}|g" \

--- a/plugins/prepare-workflow/action.yml
+++ b/plugins/prepare-workflow/action.yml
@@ -67,6 +67,28 @@ runs:
         echo GITHUB_REPOSITORY=${{ github.repository }} >> $GITHUB_ENV
         echo DEPLOY_BRANCH=$CURRENT_BRANCH | sed -e 's+\/+\-+' >> $GITHUB_ENV
       shell: bash
+
+    - name: 'update build info in manifest.yaml'
+      run: |
+        cd "$GITHUB_WORKSPACE"
+        MANIFEST_PATH=manifest.yaml
+        CURRENT_BRANCH=$(git branch --show-current)
+        COMMIT_HASH=$(git rev-parse HEAD)
+        CURRENT_TIMESTAMP=$(date +%s%3N)
+        if [ -f "$MANIFEST_PATH" ]; then
+          echo "updating $MANIFEST_PATH"
+          sed -e "s|{{build\.branch}}|${CURRENT_BRANCH}|g" \
+              -e "s|{{build\.number}}|${GITHUB_RUN_NUMBER}|g" \
+              -e "s|{{build\.commitHash}}|${COMMIT_HASH}|g" \
+              -e "s|{{build\.timestamp}}|${CURRENT_TIMESTAMP}|g" \
+              "$MANIFEST_PATH" > "${MANIFEST_PATH}.tmp"
+              mv "${MANIFEST_PATH}.tmp" "$MANIFEST_PATH"
+              echo "${MANIFEST_PATH}:"
+              cat "$MANIFEST_PATH"
+        else
+          echo "$MANIFEST_PATH not found. No build info was recorded. Please add a template manifest in this repo. explorer-jes/$MANIFEST_PATH is a good example."
+        fi
+      shell: bash
     
     - name: 'set plugin version'
       run: |


### PR DESCRIPTION
**Ported changes from PR #44 and PR #45 for v2.x/main.**

The changes in the two source PRs are seen generating correct build information in v3's staging components. Such as [tn3270-ng2-3.3.0-20250725.131346.pax](https://zowe.jfrog.io/zowe/list/libs-snapshot-local/org/zowe/zlux/tn3270-ng2/3.3.0-V3.X-STAGING/tn3270-ng2-3.3.0-20250725.131346.pax) and [zlux-core-3.3.0-20250719.064650.pax](https://zowe.jfrog.io/artifactory/list/libs-snapshot-local/org/zowe/zlux/zlux-core/3.3.0-V3.X-STAGING-ZLUX-CORE/zlux-core-3.3.0-20250719.064650.pax), so we copy the changes into v2's main branch.

Description of PR #44:
> _Fix issue #42_
> 
> _Before this change, any Zowe server components built by [zowe/zlux-build](https://github.com/zowe/zlux-build/actions) have  the `zowe/zlux-build`'s commitHash instead of their own commitHashes in their manifest.yaml. But I believe a component should always has its own commitHash in the manifest._
> 
> _With this change, a component will have their commitHash in the manifest no matter who builds it._

Description of PR #45:

> _Fix #43_
> 
> _Zlux plugins built by workflows in `zowe-actions/zlux-builds/plugins` do not have correct build-info in their manifest.yaml._
> 
> _The staging [tn3270-ng2-3.3.0-20250630.085018.pax](https://zowe.jfrog.io/artifactory/libs-snapshot-local/org/zowe/zlux/tn3270-ng2/3.3.0-V3.X-STAGING/tn3270-ng2-3.3.0-20250630.085018.pax) is an example of this problem._
> 
> _This PR adds an additional step in `zowe-actions/zlux-builds/plugins/prepare-worflow` that updates the manifest.yaml with the correct build-info._
> 
> _As a comparison, [tn3270-ng2-3.3.0-20250630.110159.pax](https://zowe.jfrog.io/artifactory/libs-snapshot-local/org/zowe/zlux/tn3270-ng2/3.3.0-USER-ZHOU/FIX-MANIFEST-BUILD-INFO/tn3270-ng2-3.3.0-20250630.110159.pax) was built by the workflow from this PR's branch. The manifest.yaml has correct build-info._