### PR TITLE
fix registry overriding scope in zlus-plugins

### DIFF
--- a/plugins/zlux-plugins/action.yml
+++ b/plugins/zlux-plugins/action.yml
@@ -19,7 +19,7 @@ runs:
         export MVD_HOME_DIR=$(pwd) 
         echo MVD_HOME_DIR=$(pwd) >> $GITHUB_ENV
         git clone -b v3.x/master https://github.com/1000TurquoisePogs/zowe-install-packaging.git
-        npm config set registry https://zowe.jfrog.io/zowe/api/npm/npm-release/
+        npm config set @zowe:registry https://zowe.jfrog.io/zowe/api/npm/npm-release/
         mkdir zlux
         cp -rf $REPOSITORY_NAME zlux/
         cd zlux


### PR DESCRIPTION
The npm repository overriding in `plugins/zlux-plugins/action.yml` is not limited to "@zowe", which forces builds to take all dependencies from the internal repository in JFrog.

However, sometimes JFrog repository doesn't have the latest packages available in npm, which causes problems for vulnerability fixing.

Therefore, I would like to limit the scope of the repository overriding.

You may take the file-explorer's README as a reference:
https://github.com/zowe/zlux-file-explorer?tab=readme-ov-file#installing-dependencies