### PR TITLE
Reduce package size

### DIFF
--- a/core/build/action.yml
+++ b/core/build/action.yml
@@ -203,6 +203,10 @@ runs:
       run: |
         chmod +x dist/zlux-build/*.sh
         cd dist
+        # Deduplicate: place canonical LICENSE and CONTRIBUTING.md at the tar root
+        cp zlux-build/LICENSE ./LICENSE
+        cp zlux-build/CONTRIBUTING.md ./CONTRIBUTING.md
+        find . -mindepth 2 \( -name "LICENSE" -o -name "CONTRIBUTING.md" \) -delete
         tar cf ../zlux.tar -H ustar *
         cd ..
         git clone -b v3.x/master https://github.com/1000TurquoisePogs/zowe-install-packaging.git

--- a/core/package/dist/index.js
+++ b/core/package/dist/index.js
@@ -136,6 +136,7 @@ cd zlux-server-framework
 rm -rf node_modules 
 export NODE_HOME=${maristNode}
 _TAG_REDIR_ERR=txt _TAG_REDIR_IN=txt _TAG_REDIR_OUT=txt __UNTAGGED_READ_MODE=V6 PATH=${maristNode}/bin:.:/bin npm --verbose install --cache /ZOWE/tmp/.npm
+_TAG_REDIR_ERR=txt _TAG_REDIR_IN=txt _TAG_REDIR_OUT=txt __UNTAGGED_READ_MODE=V6 PATH=${maristNode}/bin:.:/bin npm prune --omit=dev
 cd .. 
 iconv -f iso8859-1 -t 1047 zlux-app-server/defaults/serverConfig/server.json > zlux-app-server/defaults/serverConfig/server.json.1047 
 mv zlux-app-server/defaults/serverConfig/server.json.1047 zlux-app-server/defaults/serverConfig/server.json 

--- a/core/package/lib/pax.js
+++ b/core/package/lib/pax.js
@@ -97,6 +97,7 @@ cd zlux-server-framework
 rm -rf node_modules 
 export NODE_HOME=${maristNode}
 _TAG_REDIR_ERR=txt _TAG_REDIR_IN=txt _TAG_REDIR_OUT=txt __UNTAGGED_READ_MODE=V6 PATH=${maristNode}/bin:.:/bin npm --verbose install --cache /ZOWE/tmp/.npm
+_TAG_REDIR_ERR=txt _TAG_REDIR_IN=txt _TAG_REDIR_OUT=txt __UNTAGGED_READ_MODE=V6 PATH=${maristNode}/bin:.:/bin npm prune --omit=dev
 cd .. 
 iconv -f iso8859-1 -t 1047 zlux-app-server/defaults/serverConfig/server.json > zlux-app-server/defaults/serverConfig/server.json.1047 
 mv zlux-app-server/defaults/serverConfig/server.json.1047 zlux-app-server/defaults/serverConfig/server.json 


### PR DESCRIPTION
Reduce package size by deduplicating LICENSE and CONTRIBUTING files and removing devdeps from zsf output.